### PR TITLE
Support RPC & CTL plugins.

### DIFF
--- a/collective/recipe/supervisor/templates.py
+++ b/collective/recipe/supervisor/templates.py
@@ -79,3 +79,13 @@ INCLUDE = """
 [include]
 files = %(stringfiles)s
 """
+
+RPC_EXTRA_TEMPLATE = """
+[rpcinterface:%(name)s]
+supervisor.rpcinterface_factory=%(callable)s
+"""
+
+CTLPLUGIN_TEMPLATE = """
+[ctlplugin:%(name)s]
+supervisor.ctl_factory = %(callable)s
+"""


### PR DESCRIPTION
For example, if you want to use mr.laforge, write the supervisor section as follows:

[supervisor]
plugins =
    mr.laforge

rpcplugins =
    laforge mr.laforge.rpcinterface:make_laforge_rpcinterface

ctlplugins =
    laforge mr.laforge.controllerplugin:make_laforge_controllerplugin
