### PR TITLE
Run tests

### DIFF
--- a/collective/recipe/supervisor/tests/test_docs.py
+++ b/collective/recipe/supervisor/tests/test_docs.py
@@ -4,11 +4,12 @@ Doctest runner for 'collective.recipe.supervisor'.
 """
 __docformat__ = 'restructuredtext'
 
+import doctest
 import unittest
 import zc.buildout.tests
 import zc.buildout.testing
 
-from zope.testing import doctest, renormalizing
+from zope.testing import renormalizing
 
 optionflags = (doctest.ELLIPSIS |
                doctest.NORMALIZE_WHITESPACE |

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Change history
 0.20 (unreleased)
 =================
 
+- Fix tests to be able to run.
+  Fixes https://github.com/collective/collective.recipe.supervisor/issues/10
+  [gforcada]
+
 - fix: memscript install script did not get conf file because of a typo.
   [moriyoshi]
 


### PR DESCRIPTION
zope.testing.doctests has been long deprecated by Python standard doctest module.