### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 install:
   - python bootstrap.py
   - ./bin/buildout

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ import os
 
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    path = os.path.join(os.path.dirname(__file__), *rnames)
+    return open(path, 'rb').read().decode('utf-8')
 
 version = '0.21.dev0'
 


### PR DESCRIPTION
Locally I ran bootstrap.py and then buildout just fine with python 3. I see in Travis there are only jobs for python 2. Is python 3 actually supported? 